### PR TITLE
Update oneCommitPerDay.sh

### DIFF
--- a/oneCommitPerDay.sh
+++ b/oneCommitPerDay.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
+set -e
 
 commit_file="commitFile.txt"
 commit_message=`w3m -dump http://whatthecommit.com | head -1`
 
-# create commit_file if it does not exist
-if [ ! -f $commit_file ] ; then
-	touch $commit_file
-fi
-
 # add new content to file, commit and push
-echo "$commit_message on `date`" >> $commit_file
-git add $commit_file
-git commit -m "$commit_message"
+echo "$commit_message on `date --iso-8601`" >> $commit_file
+
+git commit $commit_file -m "$commit_message"
 git push origin master


### PR DESCRIPTION
- Better `set -e` to abort on error. For example, if `$commit_file` cannot be created.
- ~~Also short-commit by specifying the file name directly.~~
- And most importantly, always `--iso-8601`: ![](https://imgs.xkcd.com/comics/iso_8601.png)
